### PR TITLE
implement user profile functionalities on backend

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,1 +1,2 @@
 data.db
+static

--- a/backend/generate_sample_data.py
+++ b/backend/generate_sample_data.py
@@ -9,18 +9,51 @@ import sqlalchemy.orm
 engine = sqlalchemy.create_engine("sqlite:///data.db")
 models.ModelBase.metadata.create_all(engine)
 
+# Thank u Costin for letting me use your account here :))
+users = [
+    {
+        "name": "cstn",
+        "password": "pass",
+        "profile": {
+            "riot_puuid": "6EdYfH55OSo1dZlzFz3WRzK8PiOW_vqPc6DNB-vUq2eb3SkdHhIjZrFtl-zHRC2rXjSdnNv0IuzdFQ",
+            "riot_region": "EUNE",
+            "icon_id": 1
+        }
+    },
+    {
+        "name": "99 9 impulse fm",
+        "password": "pass",
+        "profile": {
+            "riot_puuid": "jB7KsGhW3CdoTQ20Em8ugdIVyCFMp9q0dI7szykzG3yjoyvEAlc15eK8Y2QWTmkf9puPSixmyPe1vA",
+            "riot_region": "EUW",
+            "icon_id": 1
+        }
+    }
+]
+
+icons = [
+    {
+        "path": "n/a"
+    }
+]
+
 with sqlalchemy.orm.Session(engine) as sess:
-    # Thank u Costin for letting me use your account here :))
-    user = models.User(
-        name="cstn",
-        password="pass",
-    )
-    user.profile = models.Profile(
-        riot_id="jdmPqyCWzzU8GK412CbHGEh9bkUmuYptt6wBrzLFm3WPNWs",
-        riot_region="EUNE",
-    )
-    user.profile.icon = models.Icon(
-        path="TODO",
-    )
-    sess.add(user)
+    for icon_data in icons:
+        icon = models.Icon(
+            path=icon_data["path"]
+        )
+        sess.add(icon)
+
+    for user_data in users:
+        user = models.User(
+            name=user_data["name"],
+            password=user_data["password"],
+        )
+        user.profile = models.Profile(
+            riot_puuid=user_data["profile"]["riot_puuid"],
+            riot_region=user_data["profile"]["riot_region"],
+            icon_id=user_data["profile"]["icon_id"]
+        )
+        sess.add(user)
+
     sess.commit()

--- a/backend/models.py
+++ b/backend/models.py
@@ -67,7 +67,7 @@ class Profile(ModelBase):
             "balance": self.balance,
             "hours_played": self.hours_played,
             "icon_id": self.icon_id,
-            "last_match_end": int(self.last_match_end.timestamp()) if self.last_match_id is not None else None,
+            "last_match_end": int(self.last_match_end.timestamp()) if self.last_match_id is not None else None
         }
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,15 +1,27 @@
 import json
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy import ForeignKey
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
 class ModelBase(DeclarativeBase):
-    def to_dict(self):
+    """ The base model class from which all the models should inherit from"""
+
+    def to_dict(self) -> dict:
+        """ Returns a dict representation of the model.
+
+        This should be implemented by the models to easily return the model's data in the response body.
+
+        Returns: a dict
+        """
         pass
 
     def to_json(self):
+        """ Returns a json formatted string as representation of the model.
+
+        Returns: json formatted string
+        """
         return json.dumps(self.to_dict())
 
 
@@ -32,10 +44,7 @@ class User(ModelBase):
 class Profile(ModelBase):
     __tablename__ = "Profile"
 
-    # NOTE(andreij): Why use riot_id+riot_region instead of puuid? Because
-    # getting a summoner by puuid is not yet supported in cassiopeia[0].
-    # [0]: https://github.com/meraki-analytics/cassiopeia/issues/441
-    riot_id: Mapped[str] = mapped_column(nullable=False, primary_key=True)
+    riot_puuid: Mapped[str] = mapped_column(nullable=False, primary_key=True)
     riot_region: Mapped[str] = mapped_column(nullable=False, primary_key=True)
 
     user_id: Mapped[int] = mapped_column(ForeignKey("User.id"), nullable=False)
@@ -53,13 +62,12 @@ class Profile(ModelBase):
 
     def to_dict(self):
         return {
-            "riot_id": self.riot_id,
+            "riot_puuid": self.riot_puuid,
             "riot_region": self.riot_region,
-            "user_id": self.user_id,
             "balance": self.balance,
             "hours_played": self.hours_played,
-            "last_match_end": int(self.last_match_end.timestamp()),
-            "icon": self.icon.to_dict()
+            "icon_id": self.icon_id,
+            "last_match_end": int(self.last_match_end.timestamp()) if self.last_match_id is not None else None,
         }
 
 

--- a/backend/src/generate_sample_data.py
+++ b/backend/src/generate_sample_data.py
@@ -1,23 +1,32 @@
 """
 Insert some sample data into the database, for testing purposes.
 """
-
+import argparse
+import json
+import pathlib
 import models
-import sqlalchemy
 import sqlalchemy.orm
+import cassiopeia as cass
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument("config_file")
+args = argparser.parse_args()
 
 engine = sqlalchemy.create_engine("sqlite:///data.db")
 models.ModelBase.metadata.create_all(engine)
+with open(args.config_file) as f:
+    config = json.load(f)
+cass.set_riot_api_key(config["riot_api_key"])
 
-# Thank u Costin for letting me use your account here :))
+
 users = [
+    # Thank u Costin for letting me use your account here :))
     {
         "name": "cstn",
         "password": "pass",
         "profile": {
             "riot_puuid": "6EdYfH55OSo1dZlzFz3WRzK8PiOW_vqPc6DNB-vUq2eb3SkdHhIjZrFtl-zHRC2rXjSdnNv0IuzdFQ",
-            "riot_region": "EUNE",
-            "icon_id": 1
+            "riot_region": "EUNE"
         }
     },
     {
@@ -25,34 +34,35 @@ users = [
         "password": "pass",
         "profile": {
             "riot_puuid": "jB7KsGhW3CdoTQ20Em8ugdIVyCFMp9q0dI7szykzG3yjoyvEAlc15eK8Y2QWTmkf9puPSixmyPe1vA",
-            "riot_region": "EUW",
-            "icon_id": 1
+            "riot_region": "EUW"
         }
     }
 ]
 
-icons = [
-    {
-        "path": "n/a"
-    }
-]
-
 with sqlalchemy.orm.Session(engine) as sess:
-    for icon_data in icons:
-        icon = models.Icon(
-            path=icon_data["path"]
-        )
-        sess.add(icon)
-
     for user_data in users:
+        # create user
         user = models.User(
             name=user_data["name"],
             password=user_data["password"],
         )
+
+        # fetch icon
+        summoner = cass.Summoner(puuid=user_data["profile"]["riot_puuid"], region=user_data["profile"]["riot_region"])
+        icon = summoner.profile_icon
+
+        # save icon and store in db
+        icon_path = f"static/icons/{icon.id}.{icon.image.format.lower()}"
+        pathlib.Path(icon_path).parent.mkdir(parents=True, exist_ok=True)
+
+        icon.image.save(icon_path)
+        new_icon = models.Icon(id=icon.id, path=icon_path)
+
+        # create profile
         user.profile = models.Profile(
             riot_puuid=user_data["profile"]["riot_puuid"],
             riot_region=user_data["profile"]["riot_region"],
-            icon_id=user_data["profile"]["icon_id"]
+            icon=new_icon
         )
         sess.add(user)
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -78,8 +78,8 @@ class UserDetailView(views.MethodView):
             # and if it is, update it
             now = datetime.now()
             if (
-                profile.last_match_updated is None or
-                now - profile.last_match_updated >= self.wait_time
+                profile.last_match_updated is None
+                or now - profile.last_match_updated >= self.wait_time
             ):
                 profile.last_match_updated = now
 

--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -62,12 +62,11 @@ class Profile(ModelBase):
 
     def to_dict(self):
         return {
-            "riot_puuid": self.riot_puuid,
-            "riot_region": self.riot_region,
+            "region": self.riot_region,
             "balance": self.balance,
             "hours_played": self.hours_played,
             "icon_id": self.icon_id,
-            "last_match_end": int(self.last_match_end.timestamp()) if self.last_match_id is not None else None
+            "last_match_end": int(self.last_match_end.timestamp()) if self.last_match_id else None
         }
 
 

--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -66,7 +66,7 @@ class Profile(ModelBase):
             "balance": self.balance,
             "hours_played": self.hours_played,
             "icon_id": self.icon_id,
-            "last_match_end": int(self.last_match_end.timestamp()) if self.last_match_id else None
+            "last_match_end": int(self.last_match_end.timestamp()) if self.last_match_id is not None else None
         }
 
 


### PR DESCRIPTION
Important changes:
- replaced riot id with puuid
- changed `last_match_end` to be the datetime when the user left the match (not the datatime when the match finished)
- added profile icons and stored them in the `static` folder

<br/>

Other:
- added more sample data (including icons)
- return HTTP 404 status code when objects are not found
- moved the modules in the `src` folder