### PR TITLE
check if name or summoner is already used in register

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -167,7 +167,17 @@ def user_register():
         )
 
         session.add(new_user)
-        session.commit()
+        try:
+            session.commit()
+        except sqlalchemy.exc.IntegrityError as ex:
+            args = set(ex.args)
+            # TODO: Better way to check for these? This will break if we change
+            # the constraints.
+            response = dict(
+                name_already_exists="(sqlite3.IntegrityError) UNIQUE constraint failed: User.name" in args,
+                summoner_already_exists="(sqlite3.IntegrityError) UNIQUE constraint failed: Profile.riot_puuid, Profile.riot_region" in args,
+            )
+            return response, status.BAD_REQUEST
         
         return new_user.to_dict(), status.OK
 


### PR DESCRIPTION
When an integrity check fails, register returns a 500 response with the following shape:

```
{
  name_already_exists: bool,
  summoner_already_exists: bool,
}
```