### PR TITLE
only return `pending`, `sender`, and `receiver` in `to_dict`

### DIFF
--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -81,12 +81,7 @@ class Friendship(ModelBase):
 
     def to_dict(self):
         return {
-            "smaller_user_id": self.smaller_user_id,
-            "smaller_user": self.smaller_user.to_dict(),
-            "bigger_user_id": self.bigger_user_id,
-            "bigger_user": self.bigger_user.to_dict(),
             "pending": self.pending,
-            "sender_is_smaller_id": self.sender_is_smaller_id,
             "sender": self.sender.to_dict(),
             "receiver": self.receiver.to_dict(),
         }


### PR DESCRIPTION
The bigger, smaller stuff is really an implementation detail.  Doesn't really matter for people using the api.